### PR TITLE
Fix: 헤더 UI 수정, 로그인 폼 watch 적용, 로고 클릭 링크 수정

### DIFF
--- a/Intervot/src/web/layouts/Header.tsx
+++ b/Intervot/src/web/layouts/Header.tsx
@@ -10,6 +10,7 @@ const Header = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const userName = useAuthStore((state) => state.user?.nickname);
   const logout = useAuthStore((state) => state.logout);
   // 로그아웃 핸들러
   const handleLogout = () => {
@@ -22,14 +23,11 @@ const Header = () => {
     <header className="w-full bg-white border-b border-gray-200 shadow-sm sticky top-0 z-50">
       <div className="w-[60%] mx-auto flex items-center  py-3">
         {/* 로고 */}
-        <Link
-          className="flex items-center cursor-pointer"
-          to={`${isAuthenticated ? "/" : "/login"}`}
-        >
+        <Link className="flex items-center cursor-pointer" to="/">
           <img src={logo} alt="로고" className="w-20 h-10 object-contain" />
         </Link>
 
-        {isAuthenticated && (
+        {isAuthenticated ? (
           <>
             {/* 메뉴탭 */}
             <nav className="flex gap-6 items-center ml-8">
@@ -63,7 +61,7 @@ const Header = () => {
                 <span className="text-gray-700 text-sm mr-2">환영합니다!</span>
                 <span className="text-blue-900 text-sm hover:font-bold transition-all">
                   {/* 추후 nickname으로 변경 */}
-                  사용자
+                  {userName}
                 </span>
                 <span className="text-gray-700 text-sm ml-1">님</span>
               </div>
@@ -93,6 +91,15 @@ const Header = () => {
               </div>
             </div>
           </>
+        ) : (
+          <div className="flex w-full justify-end gap-4">
+            <Link
+              className="px-4 py-2 rounded-md text-sm font-medium bg-blue-900 text-white hover:border hover:border-blue-900 hover:bg-white hover:text-blue-900 transition-colors"
+              to="/login"
+            >
+              로그인
+            </Link>
+          </div>
         )}
       </div>
     </header>

--- a/Intervot/src/web/pages/auth/LoginPage.tsx
+++ b/Intervot/src/web/pages/auth/LoginPage.tsx
@@ -14,11 +14,22 @@ const LoginPage = () => {
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid, isSubmitting },
+    watch,
+    formState: { errors, isSubmitting },
     trigger,
   } = useForm<LoginFormData>({
     mode: "onBlur",
   });
+
+  const watchedValues = watch();
+
+  // 이메일과 비밀번호가 모두 입력되었고 유효한지 확인
+  const isFormValid = Boolean(
+    watchedValues.email &&
+      watchedValues.password &&
+      !errors.email &&
+      !errors.password
+  );
 
   const { mutate, isPending } = useMutation({
     mutationFn: authService.login,
@@ -78,7 +89,7 @@ const LoginPage = () => {
           handleSubmit={handleSubmit}
           register={register}
           errors={errors}
-          isValid={isValid}
+          isValid={isFormValid}
           isSubmitting={isSubmitting}
           isPending={isPending}
           trigger={trigger}


### PR DESCRIPTION
📌 PR 제목
비로그인 시 헤더 UI 수정, 로그인 폼 watch 적용, 로고 클릭 링크 수정

✨ 변경 사항
- 헤더 로그인 시 사용자 실제 닉네임 사용
- 로그인 폼 입력 시 watch로 버튼 활성화
- 비로그인 시 헤더에 로그인 링크 추가
- 로고 클릭 시 항상 메인페이지 이동 처리